### PR TITLE
fix: replace deprecated apt_key with get_url + apt_repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 
 # https://pbs.proxmox.com/docs/installation.html#secureapt
 proxmox_pve_repository_key: "https://enterprise.proxmox.com/debian/proxmox-release-{{ ansible_distribution_release }}.gpg"
+proxmox_pve_repository_keyring: "/etc/apt/keyrings/proxmox-release-{{ ansible_distribution_release }}.gpg"
 
 # manages the Proxmox /etc/apt/sources.list
 proxmox_pbs_enable_default_repository: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,15 @@
 ---
-- name: Add PVE Apt signing key
-  ansible.builtin.apt_key:
+- name: Ensure /etc/apt/keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Download Proxmox PBS apt signing key
+  ansible.builtin.get_url:
     url: "{{ proxmox_pve_repository_key }}"
-    state: present
+    dest: "{{ proxmox_pve_repository_keyring }}"
+    mode: "0644"
 
 - name: Update sources.list
   ansible.builtin.template:
@@ -14,22 +21,18 @@
   when: proxmox_pbs_enable_default_repository
   register: proxmox_pbs_repository_sources_list
 
-- name: Update pbs-enterprise.list
-  ansible.builtin.template:
-    src: "etc/apt/sources.list.d/pbs-enterprise.list.j2"
-    dest: "/etc/apt/sources.list.d/pbs-enterprise.list"
-    owner: "root"
-    group: "root"
-    mode: '0644'
+- name: Configure pbs-enterprise repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by={{ proxmox_pve_repository_keyring }}] https://enterprise.proxmox.com/debian/pbs {{ ansible_distribution_release }} pbs-enterprise"
+    state: "{{ proxmox_pbs_enable_enterprise_repository | bool | ternary('present', 'absent') }}"
+    filename: pbs-enterprise
   register: proxmox_pbs_repository_enterprise_list
 
-- name: Update pbs-no-subscription.list
-  ansible.builtin.template:
-    src: "etc/apt/sources.list.d/pbs-no-subscription.list.j2"
-    dest: "/etc/apt/sources.list.d/pbs-no-subscription.list"
-    owner: "root"
-    group: "root"
-    mode: '0644'
+- name: Configure pbs-no-subscription repository
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by={{ proxmox_pve_repository_keyring }}] http://download.proxmox.com/debian/pbs {{ ansible_distribution_release }} pbs-no-subscription"
+    state: "{{ proxmox_pbs_enable_no_subscription_repository | bool | ternary('present', 'absent') }}"
+    filename: pbs-no-subscription
   register: proxmox_pbs_repository_no_subscription_list
 
 - name: Update repository cache

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,15 +11,15 @@
     dest: "{{ proxmox_pve_repository_keyring }}"
     mode: "0644"
 
-- name: Update sources.list
-  ansible.builtin.template:
-    src: "etc/apt/sources.list.j2"
-    dest: "/etc/apt/sources.list"
-    owner: "root"
-    group: "root"
-    mode: '0644'
-  when: proxmox_pbs_enable_default_repository
-  register: proxmox_pbs_repository_sources_list
+# - name: Update sources.list
+#   ansible.builtin.template:
+#     src: "etc/apt/sources.list.j2"
+#     dest: "/etc/apt/sources.list"
+#     owner: "root"
+#     group: "root"
+#     mode: '0644'
+#   when: proxmox_pbs_enable_default_repository
+#   register: proxmox_pbs_repository_sources_list
 
 - name: Configure pbs-enterprise repository
   ansible.builtin.apt_repository:
@@ -32,13 +32,13 @@
   ansible.builtin.apt_repository:
     repo: "deb [signed-by={{ proxmox_pve_repository_keyring }}] http://download.proxmox.com/debian/pbs {{ ansible_distribution_release }} pbs-no-subscription"
     state: "{{ proxmox_pbs_enable_no_subscription_repository | bool | ternary('present', 'absent') }}"
-    filename: pbs-no-subscription
+    filename: proxmox.sources
   register: proxmox_pbs_repository_no_subscription_list
 
 - name: Update repository cache
   ansible.builtin.apt:
     update_cache: true
-  when: proxmox_pbs_repository_sources_list.changed or
+  when: 
     proxmox_pbs_repository_enterprise_list.changed or
     proxmox_pbs_repository_no_subscription_list.changed
   # Data should be refreshed immediatly for other roles which depend on them

--- a/templates/etc/apt/sources.list.d/pbs-enterprise.list.j2
+++ b/templates/etc/apt/sources.list.d/pbs-enterprise.list.j2
@@ -1,7 +1,0 @@
-# PBS Enterprise Subscription Repository
-
-{% if proxmox_pbs_enable_enterprise_repository %}
-deb https://enterprise.proxmox.com/debian/pbs {{ ansible_distribution_release }} pbs-enterprise
-{% else %}
-# deb https://enterprise.proxmox.com/debian/pbs {{ ansible_distribution_release }} pbs-enterprise
-{% endif %}

--- a/templates/etc/apt/sources.list.d/pbs-no-subscription.list.j2
+++ b/templates/etc/apt/sources.list.d/pbs-no-subscription.list.j2
@@ -1,8 +1,0 @@
-# PBS pbs-no-subscription repository provided by proxmox.com,
-# NOT recommended for production use
-
-{% if proxmox_pbs_enable_no_subscription_repository %}
-deb http://download.proxmox.com/debian/pbs {{ ansible_distribution_release }} pbs-no-subscription
-{% else %}
-# deb http://download.proxmox.com/debian/pbs {{ ansible_distribution_release }} pbs-no-subscription
-{% endif %}


### PR DESCRIPTION
- Download signing key to /etc/apt/keyrings/ via get_url
- Manage repo entries with apt_repository (signed-by=) instead of templates
- Remove pbs-enterprise.list.j2 and pbs-no-subscription.list.j2 (no longer needed)
- Add proxmox_pve_repository_keyring default variable